### PR TITLE
Update error message for daemon on Windows

### DIFF
--- a/bin/chef-zero
+++ b/bin/chef-zero
@@ -93,7 +93,11 @@ if options[:daemon]
     Process.daemon(true)
     server.start(true)
   else
-    abort 'Process.daemon requires Ruby >= 1.9'
+    if ENV['OS'] == 'Windows_NT' 
+      abort 'Daemonization is not supported on Windows. Running 'start chef-zero' will fork the process.'
+    else
+      abort 'Process.daemon requires Ruby >= 1.9'
+    end
   end
 else
   server.start(true)


### PR DESCRIPTION
When running chef-zero with the daemon option on Windows, the error message incorrectly says 'Process.daemon requires Ruby >= 1.9', even when Windows has Ruby 2.0+.
